### PR TITLE
Typo fix: Veryfing -> Verifying

### DIFF
--- a/lib/licensing.js
+++ b/lib/licensing.js
@@ -16,7 +16,7 @@ var mkdirpAsync = Promise.promisify(mkdirp)
 function verifyLicenseKey (reporter, definition, key) {
   var trimmedKey = key.trim()
 
-  reporter.logger.info('Veryfing license key ' + trimmedKey)
+  reporter.logger.info('Verifying license key ' + trimmedKey)
   return countTemplates(reporter).then(function (count) {
     return verifyInCache(reporter, definition, {
       licenseKey: trimmedKey,


### PR DESCRIPTION
Noticed a typo on the console log when the licensing module was coming up on my instance of the jsreport server. Fixed it.